### PR TITLE
Run scripts from other folders

### DIFF
--- a/yeelight.sh
+++ b/yeelight.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Put all your Yeelights separated by spaces in yeelight-ips
-declare -a ID=($(cat ./yeelight-ips))
+declare -a ID=($(cat $(dirname $0)/yeelight-ips))
 
 if [[ "$#" -ne 2 ]]; then
   echo "Usage: $( basename $0 ) <ID> <JSON>"


### PR DESCRIPTION
If we run the scripts from other folder than the root folder of yeelight shell scripts, the yeelight-ips is not found (the script tries to find it in the current folder).

With this change, the yeelight-ips file is in the same folder than the .sh scripts, and the yeelight shell scripts always find it.