### PR TITLE
Add usage of `env` to run bash instead of /bin/bash

### DIFF
--- a/yeelight-brightness.sh
+++ b/yeelight-brightness.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 IDMSG="ID must be a number"
 BRIMSG="BRIGHTNESS must be a number between 0 and 100"

--- a/yeelight-colortemp.sh
+++ b/yeelight-colortemp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 IDMSG="ID must be a number"
 CTMSG="CT must be Kelvin between 1700 and 6500"

--- a/yeelight-disco.sh
+++ b/yeelight-disco.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wrapper for HA-Bridge to pass in ${intensity.percent} and do some math
 DISCOSPEED=$(( ($1 - 1) * 20 + 30 )) $( dirname $0 )/yeelight-scene.sh 0 Disco

--- a/yeelight-hue.sh
+++ b/yeelight-hue.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 IDMSG="ID must be a number"
 HUEMSG="HUE must be a number between 0 and 359"

--- a/yeelight-redshift.sh
+++ b/yeelight-redshift.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 redshift -p &> redshift_out
 string=$(cat redshift_out | grep Color)

--- a/yeelight-rgb.sh
+++ b/yeelight-rgb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -E
 trap '[ "$?" -ne 99 ] || exit 99' ERR

--- a/yeelight-scene.sh
+++ b/yeelight-scene.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Setup your scenes and adjust the scenes below
 SCENES="On|Off|Sunrise|Sunset|Sleep|Rainbow|Disco|2700|4300|6500|Off1Min|Stop|Dim|Warm"

--- a/yeelight-toggle.sh
+++ b/yeelight-toggle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 IDMSG="ID must be a number"
 

--- a/yeelight.sh
+++ b/yeelight.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Put all your Yeelights separated by spaces in yeelight-ips
 declare -a ID=($(cat $(dirname $0)/yeelight-ips))
 


### PR DESCRIPTION
Hello Heinz!

I changed the usage of `/bin/bash` to `/usr/bin/env bash` because different Operating Systems might have `bash` located somewhere else.

Thank you for this great piece of software!